### PR TITLE
On branch fix-mmio_offset

### DIFF
--- a/src/pynq_api.c
+++ b/src/pynq_api.c
@@ -704,7 +704,7 @@ int PYNQ_closeMMIOWindow(PYNQ_MMIO_WINDOW * state) {
 * Writes some data, of provided size to the specified offset in the memory window
 */
 int PYNQ_writeMMIO(PYNQ_MMIO_WINDOW * state, void * data, size_t offset, size_t size_data) {
-  memcpy(&(state->buffer[offset]), data, size_data);
+  memcpy(&(state->buffer[state->virt_offset + offset]), data, size_data);
   return PYNQ_SUCCESS;
 }
 
@@ -712,7 +712,7 @@ int PYNQ_writeMMIO(PYNQ_MMIO_WINDOW * state, void * data, size_t offset, size_t 
 * Reads some data, of provided size to the specified offset from the memory window
 */
 int PYNQ_readMMIO(PYNQ_MMIO_WINDOW * state, void * data, size_t offset, size_t size_data) {
-  memcpy(data, &(state->buffer[offset]), size_data);
+  memcpy(data, &(state->buffer[state->virt_offset + offset]), size_data);
   return PYNQ_SUCCESS;
 }
 


### PR DESCRIPTION
Changes to be committed:
	modified:   src/pynq_api.c

Fixed the offset for MMIO to an axi interface with smaller alignment than page size.

If you use a range in the axi-slave smaller than the page size (4kB) and start the address not-aligned to the page size the memory is mapped correctly but the virtual offset is not added when accessing the buffer.

Example:
Create AXI-GPIO with range 128 and Master Base Address 0x4120_0080 will lead to PYNQ_writeMMIO() writing to the register 0x4120_0000 if it exists.

Adding the virtual offset when accessing the buffer fixes this.